### PR TITLE
Change usage of `startsWith` for older browsers.

### DIFF
--- a/src/object-position.ts
+++ b/src/object-position.ts
@@ -58,7 +58,7 @@ export function getPositioningTranslate(
   // center.
   const positionStr = objectPosition || '50% 50%';
 
-  const splitIndex = positionStr.startsWith('calc') ?
+  const splitIndex = positionStr.lastIndexOf('calc', 0) === 0 ?
       positionStr.indexOf(')') + 1 : positionStr.indexOf(' ');
   const xPos = positionStr.slice(0, splitIndex) || '';
   const yPos = positionStr.slice(splitIndex) || '';


### PR DESCRIPTION
This makes sure the code works when not polyfilling es2015 methods (e.g. in AMP).

Fixes #14