### PR TITLE
Update Tsickle and create CLI for processing local files

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
     "karma": "karma start --browsers Chrome,Firefox karma.conf.js",
     "test": "npm run karma -- --single-run",
     "test-watch": "npm run karma -- --auto-watch",
-    "tsickle": "node_modules/tsickle/src/main.js",
+    "tsickle": "tsickle/tsickle.js",
     "prepublish": "npm run dist"
   },
   "devDependencies": {
@@ -41,8 +41,8 @@
     "karma-typescript": "^3.0.13",
     "mocha": "^5.2.0",
     "opener": "^1.5.1",
-    "tsickle": "^0.33.0",
-    "typescript": "git://github.com/mprobst/TypeScript.git#5456479a4a"
+    "tsickle": "0.37.1",
+    "typescript": "3.6.4"
   },
   "dependencies": {},
   "files": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -16,7 +16,7 @@
     "module": "commonjs",
     "target": "es2015",
     "lib": ["es2015", "dom"],
-    "sourceMap": true
+    "sourceMap": false
   },
   "include": [
     "index.ts",

--- a/tsickle/package-lock.json
+++ b/tsickle/package-lock.json
@@ -1,0 +1,205 @@
+{
+  "name": "tsickle-cli",
+  "version": "0.0.1",
+  "lockfileVersion": 1,
+  "requires": true,
+  "dependencies": {
+    "@types/minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/@types/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=",
+      "dev": true
+    },
+    "@types/mkdirp": {
+      "version": "0.5.2",
+      "resolved": "https://registry.npmjs.org/@types/mkdirp/-/mkdirp-0.5.2.tgz",
+      "integrity": "sha512-U5icWpv7YnZYGsN4/cmh3WD2onMY0aJIiTE6+51TwJCttdHvtCYmkBNOobHlXwrJRL0nkH9jH4kD+1FAdMN4Tg==",
+      "dev": true,
+      "requires": {
+        "@types/node": "*"
+      }
+    },
+    "@types/node": {
+      "version": "10.17.4",
+      "resolved": "https://registry.npmjs.org/@types/node/-/node-10.17.4.tgz",
+      "integrity": "sha512-F2pgg+LcIr/elguz+x+fdBX5KeZXGUOp7TV8M0TVIrDezYLFRNt8oMTyps0VQ1kj5WGGoR18RdxnRDHXrIFHMQ==",
+      "dev": true
+    },
+    "balanced-match": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/balanced-match/-/balanced-match-1.0.0.tgz",
+      "integrity": "sha1-ibTRmasr7kneFk6gK4nORi1xt2c=",
+      "dev": true
+    },
+    "brace-expansion": {
+      "version": "1.1.11",
+      "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
+      "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
+      "dev": true,
+      "requires": {
+        "balanced-match": "^1.0.0",
+        "concat-map": "0.0.1"
+      }
+    },
+    "concat-map": {
+      "version": "0.0.1",
+      "resolved": "https://registry.npmjs.org/concat-map/-/concat-map-0.0.1.tgz",
+      "integrity": "sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=",
+      "dev": true
+    },
+    "es6-object-assign": {
+      "version": "1.1.0",
+      "resolved": "https://registry.npmjs.org/es6-object-assign/-/es6-object-assign-1.1.0.tgz",
+      "integrity": "sha1-wsNYJlYkfDnqEHyx5mUrb58kUjw=",
+      "dev": true
+    },
+    "fs.realpath": {
+      "version": "1.0.0",
+      "resolved": "https://registry.npmjs.org/fs.realpath/-/fs.realpath-1.0.0.tgz",
+      "integrity": "sha1-FQStJSMVjKpA20onh8sBQRmU6k8=",
+      "dev": true
+    },
+    "glob": {
+      "version": "7.1.6",
+      "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.6.tgz",
+      "integrity": "sha512-LwaxwyZ72Lk7vZINtNNrywX0ZuLyStrdDtabefZKAY5ZGJhVtgdznluResxNmPitE0SAO+O26sWTHeKSI2wMBA==",
+      "dev": true,
+      "requires": {
+        "fs.realpath": "^1.0.0",
+        "inflight": "^1.0.4",
+        "inherits": "2",
+        "minimatch": "^3.0.4",
+        "once": "^1.3.0",
+        "path-is-absolute": "^1.0.0"
+      }
+    },
+    "inflight": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
+      "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
+      "dev": true,
+      "requires": {
+        "once": "^1.3.0",
+        "wrappy": "1"
+      }
+    },
+    "inherits": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/inherits/-/inherits-2.0.4.tgz",
+      "integrity": "sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==",
+      "dev": true
+    },
+    "interpret": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/interpret/-/interpret-1.2.0.tgz",
+      "integrity": "sha512-mT34yGKMNceBQUoVn7iCDKDntA7SC6gycMAWzGx1z/CMCTV7b2AAtXlo3nRyHZ1FelRkQbQjprHSYGwzLtkVbw==",
+      "dev": true
+    },
+    "minimatch": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
+      "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
+      "dev": true,
+      "requires": {
+        "brace-expansion": "^1.1.7"
+      }
+    },
+    "minimist": {
+      "version": "1.2.0",
+      "resolved": "https://registry.npmjs.org/minimist/-/minimist-1.2.0.tgz",
+      "integrity": "sha1-o1AIsg9BOD7sH7kU9M1d95omQoQ="
+    },
+    "mkdirp": {
+      "version": "0.5.1",
+      "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
+      "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
+      "requires": {
+        "minimist": "0.0.8"
+      },
+      "dependencies": {
+        "minimist": {
+          "version": "0.0.8",
+          "resolved": "https://registry.npmjs.org/minimist/-/minimist-0.0.8.tgz",
+          "integrity": "sha1-hX/Kv8M5fSYluCKCYuhqp6ARsF0="
+        }
+      }
+    },
+    "once": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
+      "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
+      "dev": true,
+      "requires": {
+        "wrappy": "1"
+      }
+    },
+    "path-is-absolute": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/path-is-absolute/-/path-is-absolute-1.0.1.tgz",
+      "integrity": "sha1-F0uSaHNVNP+8es5r9TpanhtcX18=",
+      "dev": true
+    },
+    "path-parse": {
+      "version": "1.0.6",
+      "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.6.tgz",
+      "integrity": "sha512-GSmOT2EbHrINBf9SR7CDELwlJ8AENk3Qn7OikK4nFYAu3Ote2+JYNVvkpAEQm3/TLNEJFD/xZJjzyxg3KBWOzw==",
+      "dev": true
+    },
+    "rechoir": {
+      "version": "0.6.2",
+      "resolved": "https://registry.npmjs.org/rechoir/-/rechoir-0.6.2.tgz",
+      "integrity": "sha1-hSBLVNuoLVdC4oyWdW70OvUOM4Q=",
+      "dev": true,
+      "requires": {
+        "resolve": "^1.1.6"
+      }
+    },
+    "resolve": {
+      "version": "1.12.0",
+      "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.12.0.tgz",
+      "integrity": "sha512-B/dOmuoAik5bKcD6s6nXDCjzUKnaDvdkRyAk6rsmsKLipWj4797iothd7jmmUhWTfinVMU+wc56rYKsit2Qy4w==",
+      "dev": true,
+      "requires": {
+        "path-parse": "^1.0.6"
+      }
+    },
+    "shelljs": {
+      "version": "0.8.3",
+      "resolved": "https://registry.npmjs.org/shelljs/-/shelljs-0.8.3.tgz",
+      "integrity": "sha512-fc0BKlAWiLpwZljmOvAOTE/gXawtCoNrP5oaY7KIaQbbyHeQVg01pSEuEGvGh3HEdBU4baCD7wQBwADmM/7f7A==",
+      "dev": true,
+      "requires": {
+        "glob": "^7.0.0",
+        "interpret": "^1.0.0",
+        "rechoir": "^0.6.2"
+      }
+    },
+    "shx": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/shx/-/shx-0.3.2.tgz",
+      "integrity": "sha512-aS0mWtW3T2sHAenrSrip2XGv39O9dXIFUqxAEWHEOS1ePtGIBavdPJY1kE2IHl14V/4iCbUiNDPGdyYTtmhSoA==",
+      "dev": true,
+      "requires": {
+        "es6-object-assign": "^1.0.3",
+        "minimist": "^1.2.0",
+        "shelljs": "^0.8.1"
+      }
+    },
+    "tsickle": {
+      "version": "0.37.1",
+      "resolved": "https://registry.npmjs.org/tsickle/-/tsickle-0.37.1.tgz",
+      "integrity": "sha512-0GwgOJEnsmRsrONXCvcbAWY0CvdqF3UugPVoupUpA8Ul0qCPTuqqq0ou/hLqtKZOyyulzCP6MYRjb9/J1g9bJg=="
+    },
+    "typescript": {
+      "version": "3.5.3",
+      "resolved": "https://registry.npmjs.org/typescript/-/typescript-3.5.3.tgz",
+      "integrity": "sha512-ACzBtm/PhXBDId6a6sDJfroT2pOWt/oOnk4/dElG5G33ZL776N3Y6/6bKZJBFpd+b05F3Ct9qDjMeJmRWtE2/g=="
+    },
+    "wrappy": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/wrappy/-/wrappy-1.0.2.tgz",
+      "integrity": "sha1-tSQ9jz7BqjXxNkYFvA0QNuMKtp8=",
+      "dev": true
+    }
+  }
+}

--- a/tsickle/package.json
+++ b/tsickle/package.json
@@ -1,0 +1,22 @@
+{
+  "name": "tsickle-cli",
+  "version": "0.0.1",
+  "description": "Use tsickle Sample App to convert TS to CC types",
+  "license": "Apache-2.0",
+  "private": true,
+  "scripts": {
+    "build": "node_modules/typescript/bin/tsc; shx chmod a+x tsickle.js"
+  },
+  "dependencies": {
+    "minimist": "1.2.0",
+    "mkdirp": "0.5.1",
+    "tsickle": "0.37.1",
+    "typescript": "~3.5.3"
+  },
+  "devDependencies": {
+    "@types/minimist": "1.2.0",
+    "@types/mkdirp": "0.5.2",
+    "@types/node": "12.12.6",
+    "shx": "0.3.2"
+  }
+}

--- a/tsickle/tsconfig.json
+++ b/tsickle/tsconfig.json
@@ -1,0 +1,7 @@
+{
+  "compilerOptions": {
+    "target": "es2017",
+    "module": "commonjs",
+    "strict": true
+  }
+}

--- a/tsickle/tsickle.js
+++ b/tsickle/tsickle.js
@@ -1,0 +1,192 @@
+#!/usr/bin/env node
+"use strict";
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+Object.defineProperty(exports, "__esModule", { value: true });
+const fs = require("fs");
+const minimist = require("minimist");
+const mkdirp = require("mkdirp");
+const path = require("path");
+const ts = require("typescript");
+const tsickle = require("tsickle/src/tsickle");
+function usage() {
+    console.error(`usage: tsickle [tsickle options] -- [tsc options]
+example:
+  tsickle --externs=foo/externs.js -- -p src --noImplicitAny
+tsickle flags are:
+  --externs=PATH        save generated Closure externs.js to PATH
+  --typed               [experimental] attempt to provide Closure types instead of {?}
+  --fatalWarnings       whether warnings should be fatal, and cause tsickle to return a non-zero exit code
+`);
+}
+/**
+ * Parses the command-line arguments, extracting the tsickle settings and
+ * the arguments to pass on to tsc.
+ */
+function loadSettingsFromArgs(args) {
+    const settings = {};
+    const parsedArgs = minimist(args);
+    for (const flag of Object.keys(parsedArgs)) {
+        switch (flag) {
+            case 'h':
+            case 'help':
+                usage();
+                process.exit(0);
+                break;
+            case 'externs':
+                settings.externsPath = parsedArgs[flag];
+                break;
+            case 'typed':
+                settings.isTyped = true;
+                break;
+            case 'verbose':
+                settings.verbose = true;
+                break;
+            case 'fatalWarnings':
+                settings.fatalWarnings = true;
+                break;
+            case '_':
+                // This is part of the minimist API, and holds args after the '--'.
+                break;
+            default:
+                console.error(`unknown flag '--${flag}'`);
+                usage();
+                process.exit(1);
+        }
+    }
+    // Arguments after the '--' arg are arguments to tsc.
+    const tscArgs = parsedArgs['_'];
+    return { settings, tscArgs };
+}
+/**
+ * Determine the lowest-level common parent directory of the given list of files.
+ */
+function getCommonParentDirectory(fileNames) {
+    const pathSplitter = /[\/\\]+/;
+    const commonParent = fileNames[0].split(pathSplitter);
+    for (let i = 1; i < fileNames.length; i++) {
+        const thisPath = fileNames[i].split(pathSplitter);
+        let j = 0;
+        while (thisPath[j] === commonParent[j]) {
+            j++;
+        }
+        commonParent.length = j; // Truncate without copying the array
+    }
+    if (commonParent.length === 0) {
+        return '/';
+    }
+    else {
+        return commonParent.join(path.sep);
+    }
+}
+exports.getCommonParentDirectory = getCommonParentDirectory;
+/**
+ * Loads the tsconfig.json from a directory.
+ *
+ * TODO(martinprobst): use ts.findConfigFile to match tsc behaviour.
+ *
+ * @param args tsc command-line arguments.
+ */
+function loadTscConfig(args) {
+    // Gather tsc options/input files from command line.
+    let { options, fileNames, errors } = ts.parseCommandLine(args);
+    if (errors.length > 0) {
+        return { options: {}, fileNames: [], errors };
+    }
+    // Store file arguments
+    const tsFileArguments = fileNames;
+    // Read further settings from tsconfig.json.
+    const projectDir = options.project || '.';
+    const configFileName = path.join(projectDir, 'tsconfig.json');
+    const { config: json, error } = ts.readConfigFile(configFileName, path => fs.readFileSync(path, 'utf-8'));
+    if (error) {
+        return { options: {}, fileNames: [], errors: [error] };
+    }
+    ({ options, fileNames, errors } =
+        ts.parseJsonConfigFileContent(json, ts.sys, projectDir, options, configFileName));
+    if (errors.length > 0) {
+        return { options: {}, fileNames: [], errors };
+    }
+    // if file arguments were given to the typescript transpiler then transpile only those files
+    fileNames = tsFileArguments.length > 0 ? tsFileArguments : fileNames;
+    return { options, fileNames, errors: [] };
+}
+/**
+ * Compiles TypeScript code into Closure-compiler-ready JS.
+ */
+function toClosureJS(options, fileNames, settings, writeFile) {
+    // Use absolute paths to determine what files to process since files may be imported using
+    // relative or absolute paths
+    const absoluteFileNames = fileNames.map(i => path.resolve(i));
+    const compilerHost = ts.createCompilerHost(options);
+    const program = ts.createProgram(absoluteFileNames, options, compilerHost);
+    const filesToProcess = new Set(absoluteFileNames);
+    const rootModulePath = options.rootDir || getCommonParentDirectory(absoluteFileNames);
+    const transformerHost = {
+        shouldSkipTsickleProcessing: (fileName) => {
+            return !filesToProcess.has(path.resolve(fileName));
+        },
+        shouldIgnoreWarningsForPath: (fileName) => !settings.fatalWarnings,
+        pathToModuleName: (context, fileName) => tsickle.pathToModuleName(rootModulePath, context, fileName),
+        fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
+        es5Mode: true,
+        googmodule: true,
+        transformDecorators: true,
+        transformTypesToClosure: true,
+        typeBlackListPaths: new Set(),
+        untyped: false,
+        logWarning: (warning) => console.error(ts.formatDiagnostics([warning], compilerHost)),
+        options,
+        moduleResolutionHost: compilerHost,
+    };
+    const diagnostics = ts.getPreEmitDiagnostics(program);
+    if (diagnostics.length > 0) {
+        return {
+            diagnostics,
+            modulesManifest: new tsickle.ModulesManifest(),
+            externs: {},
+            emitSkipped: true,
+            emittedFiles: [],
+        };
+    }
+    return tsickle.emit(program, transformerHost, writeFile);
+}
+exports.toClosureJS = toClosureJS;
+function main(args) {
+    const { settings, tscArgs } = loadSettingsFromArgs(args);
+    const config = loadTscConfig(tscArgs);
+    if (config.errors.length) {
+        console.error(ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options)));
+        return 1;
+    }
+    if (config.options.module !== ts.ModuleKind.CommonJS) {
+        // This is not an upstream TypeScript diagnostic, therefore it does not go
+        // through the diagnostics array mechanism.
+        console.error('tsickle converts TypeScript modules to Closure modules via CommonJS internally. ' +
+            'Set tsconfig.js "module": "commonjs"');
+        return 1;
+    }
+    // Run tsickle+TSC to convert inputs to Closure JS files.
+    const result = toClosureJS(config.options, config.fileNames, settings, (filePath, contents) => {
+        mkdirp.sync(path.dirname(filePath));
+        fs.writeFileSync(filePath, contents, { encoding: 'utf-8' });
+    });
+    if (result.diagnostics.length) {
+        console.error(ts.formatDiagnostics(result.diagnostics, ts.createCompilerHost(config.options)));
+        return 1;
+    }
+    if (settings.externsPath) {
+        mkdirp.sync(path.dirname(settings.externsPath));
+        fs.writeFileSync(settings.externsPath, tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));
+    }
+    return 0;
+}
+// CLI entry point
+if (require.main === module) {
+    process.exit(main(process.argv.splice(2)));
+}

--- a/tsickle/tsickle.ts
+++ b/tsickle/tsickle.ts
@@ -1,0 +1,228 @@
+#!/usr/bin/env node
+
+/**
+ * @license
+ * Copyright Google Inc. All Rights Reserved.
+ *
+ * Use of this source code is governed by an MIT-style license that can be
+ * found in the LICENSE file at https://angular.io/license
+ */
+
+import * as fs from 'fs';
+import * as minimist from 'minimist';
+import * as mkdirp from 'mkdirp';
+import * as path from 'path';
+import * as ts from 'typescript';
+import * as tsickle from 'tsickle';
+
+/** Tsickle settings passed on the command line. */
+export interface Settings {
+  /** If provided, path to save externs to. */
+  externsPath?: string;
+
+  /** If provided, attempt to provide types rather than {?}. */
+  isTyped?: boolean;
+
+  /** If true, log internal debug warnings to the console. */
+  verbose?: boolean;
+
+  /** If true, warnings cause a non-zero exit code. */
+  fatalWarnings?: boolean;
+}
+
+function usage() {
+  console.error(`usage: tsickle [tsickle options] -- [tsc options]
+example:
+  tsickle --externs=foo/externs.js -- -p src --noImplicitAny
+tsickle flags are:
+  --externs=PATH        save generated Closure externs.js to PATH
+  --typed               [experimental] attempt to provide Closure types instead of {?}
+  --fatalWarnings       whether warnings should be fatal, and cause tsickle to return a non-zero exit code
+`);
+}
+
+/**
+ * Parses the command-line arguments, extracting the tsickle settings and
+ * the arguments to pass on to tsc.
+ */
+function loadSettingsFromArgs(args: string[]): {settings: Settings, tscArgs: string[]} {
+  const settings: Settings = {};
+  const parsedArgs = minimist(args);
+  for (const flag of Object.keys(parsedArgs)) {
+    switch (flag) {
+      case 'h':
+      case 'help':
+        usage();
+        process.exit(0);
+        break;
+      case 'externs':
+        settings.externsPath = parsedArgs[flag];
+        break;
+      case 'typed':
+        settings.isTyped = true;
+        break;
+      case 'verbose':
+        settings.verbose = true;
+        break;
+      case 'fatalWarnings':
+        settings.fatalWarnings = true;
+        break;
+      case '_':
+        // This is part of the minimist API, and holds args after the '--'.
+        break;
+      default:
+        console.error(`unknown flag '--${flag}'`);
+        usage();
+        process.exit(1);
+    }
+  }
+  // Arguments after the '--' arg are arguments to tsc.
+  const tscArgs = parsedArgs['_'];
+  return {settings, tscArgs};
+}
+
+/**
+ * Determine the lowest-level common parent directory of the given list of files.
+ */
+export function getCommonParentDirectory(fileNames: string[]): string {
+  const pathSplitter = /[\/\\]+/;
+  const commonParent = fileNames[0].split(pathSplitter);
+  for (let i = 1; i < fileNames.length; i++) {
+    const thisPath = fileNames[i].split(pathSplitter);
+    let j = 0;
+    while (thisPath[j] === commonParent[j]) {
+      j++;
+    }
+    commonParent.length = j;  // Truncate without copying the array
+  }
+  if (commonParent.length === 0) {
+    return '/';
+  } else {
+    return commonParent.join(path.sep);
+  }
+}
+
+/**
+ * Loads the tsconfig.json from a directory.
+ *
+ * TODO(martinprobst): use ts.findConfigFile to match tsc behaviour.
+ *
+ * @param args tsc command-line arguments.
+ */
+function loadTscConfig(args: string[]):
+    {options: ts.CompilerOptions, fileNames: string[], errors: ts.Diagnostic[]} {
+  // Gather tsc options/input files from command line.
+  let {options, fileNames, errors} = ts.parseCommandLine(args);
+  if (errors.length > 0) {
+    return {options: {}, fileNames: [], errors};
+  }
+
+  // Store file arguments
+  const tsFileArguments = fileNames;
+
+  // Read further settings from tsconfig.json.
+  const projectDir = options.project || '.';
+  const configFileName = path.join(projectDir, 'tsconfig.json');
+  const {config: json, error} =
+      ts.readConfigFile(configFileName, path => fs.readFileSync(path, 'utf-8'));
+  if (error) {
+    return {options: {}, fileNames: [], errors: [error]};
+  }
+  ({options, fileNames, errors} =
+       ts.parseJsonConfigFileContent(json, ts.sys, projectDir, options, configFileName));
+  if (errors.length > 0) {
+    return {options: {}, fileNames: [], errors};
+  }
+
+  // if file arguments were given to the typescript transpiler then transpile only those files
+  fileNames = tsFileArguments.length > 0 ? tsFileArguments : fileNames;
+
+  return {options, fileNames, errors: []};
+}
+
+/**
+ * Compiles TypeScript code into Closure-compiler-ready JS.
+ */
+export function toClosureJS(
+    options: ts.CompilerOptions, fileNames: string[], settings: Settings,
+    writeFile: ts.WriteFileCallback): tsickle.EmitResult {
+  // Use absolute paths to determine what files to process since files may be imported using
+  // relative or absolute paths
+  const absoluteFileNames = fileNames.map(i => path.resolve(i));
+
+  const compilerHost = ts.createCompilerHost(options);
+  const program = ts.createProgram(absoluteFileNames, options, compilerHost);
+  const filesToProcess = new Set(absoluteFileNames);
+  const rootModulePath = options.rootDir || getCommonParentDirectory(absoluteFileNames);
+  const transformerHost: tsickle.TsickleHost = {
+    shouldSkipTsickleProcessing: (fileName: string) => {
+      return !filesToProcess.has(path.resolve(fileName));
+    },
+    shouldIgnoreWarningsForPath: (fileName: string) => !settings.fatalWarnings,
+    pathToModuleName: (context, fileName) =>
+        tsickle.pathToModuleName(rootModulePath, context, fileName),
+    fileNameToModuleId: (fileName) => path.relative(rootModulePath, fileName),
+    es5Mode: true,
+    googmodule: true,
+    transformDecorators: true,
+    transformTypesToClosure: true,
+    typeBlackListPaths: new Set(),
+    untyped: false,
+    logWarning: (warning) => console.error(ts.formatDiagnostics([warning], compilerHost)),
+    options,
+    moduleResolutionHost: compilerHost,
+  };
+  const diagnostics = ts.getPreEmitDiagnostics(program);
+  if (diagnostics.length > 0) {
+    return {
+      diagnostics,
+      modulesManifest: new tsickle.ModulesManifest(),
+      externs: {},
+      emitSkipped: true,
+      emittedFiles: [],
+    };
+  }
+  return tsickle.emit(program, transformerHost, writeFile);
+}
+
+function main(args: string[]): number {
+  const {settings, tscArgs} = loadSettingsFromArgs(args);
+  const config = loadTscConfig(tscArgs);
+  if (config.errors.length) {
+    console.error(ts.formatDiagnostics(config.errors, ts.createCompilerHost(config.options)));
+    return 1;
+  }
+
+  if (config.options.module !== ts.ModuleKind.CommonJS) {
+    // This is not an upstream TypeScript diagnostic, therefore it does not go
+    // through the diagnostics array mechanism.
+    console.error(
+        'tsickle converts TypeScript modules to Closure modules via CommonJS internally. ' +
+        'Set tsconfig.js "module": "commonjs"');
+    return 1;
+  }
+
+  // Run tsickle+TSC to convert inputs to Closure JS files.
+  const result = toClosureJS(
+      config.options, config.fileNames, settings, (filePath: string, contents: string) => {
+        mkdirp.sync(path.dirname(filePath));
+        fs.writeFileSync(filePath, contents, {encoding: 'utf-8'});
+      });
+  if (result.diagnostics.length) {
+    console.error(ts.formatDiagnostics(result.diagnostics, ts.createCompilerHost(config.options)));
+    return 1;
+  }
+
+  if (settings.externsPath) {
+    mkdirp.sync(path.dirname(settings.externsPath));
+    fs.writeFileSync(
+        settings.externsPath,
+        tsickle.getGeneratedExterns(result.externs, config.options.rootDir || ''));
+  }
+  return 0;
+}
+
+// CLI entry point
+if (require.main === module) {
+  process.exit(main(process.argv.splice(2)));
+}


### PR DESCRIPTION
Start of work to update tsickle to latest version (which has removed the default CLI).

This work unlocks updating dependencies with security vulnerabilities.